### PR TITLE
Avoid memory leak by removing cyclic dependency.

### DIFF
--- a/assembly/api-generic.ts
+++ b/assembly/api-generic.ts
@@ -116,6 +116,10 @@ export function runVm(input: VmInput, logs: boolean = false): VmOutput {
   output.pc = int.pc;
   output.gas = int.gas.get();
   output.memory = getOutputChunks(int.memory);
+
+  // release used pages back
+  int.memory.free();
+
   return output;
 }
 

--- a/assembly/api-generic.ts
+++ b/assembly/api-generic.ts
@@ -119,7 +119,6 @@ export function runVm(input: VmInput, logs: boolean = false): VmOutput {
 
   // release used pages back
   int.memory.free();
-  builder.destroy();
 
   return output;
 }

--- a/assembly/api-generic.ts
+++ b/assembly/api-generic.ts
@@ -61,7 +61,6 @@ export function getAssembly(p: Program): string {
       v += ` ${argsArray[i]}, `;
     }
     i += skipBytes;
-    console.log(`${v}, nextPC: ${i}`);
   }
   return v;
 }
@@ -73,7 +72,8 @@ export function runVm(input: VmInput, logs: boolean = false): VmOutput {
   for (let r = 0; r < registers.length; r++) {
     registers[r] = input.registers[r];
   }
-  const memory = buildMemory(input.pageMap, input.memory);
+  const builder = new MemoryBuilder();
+  const memory = buildMemory(builder, input.pageMap, input.memory);
 
   const int = new Interpreter(p, registers, memory);
   int.nextPc = -1;
@@ -119,6 +119,7 @@ export function runVm(input: VmInput, logs: boolean = false): VmOutput {
 
   // release used pages back
   int.memory.free();
+  builder.destroy();
 
   return output;
 }
@@ -158,8 +159,7 @@ export function getOutputChunks(memory: Memory): InitialChunk[] {
   return chunks;
 }
 
-export function buildMemory(pages: InitialPage[], chunks: InitialChunk[]): Memory {
-  const builder = new MemoryBuilder();
+export function buildMemory(builder: MemoryBuilder, pages: InitialPage[], chunks: InitialChunk[]): Memory {
   for (let i = 0; i < pages.length; i++) {
     const initPage = pages[i];
     builder.setData(initPage.access, initPage.address, new Uint8Array(initPage.length));

--- a/assembly/api.ts
+++ b/assembly/api.ts
@@ -2,11 +2,13 @@ import { InitialChunk, InitialPage, buildMemory } from "./api-generic";
 import { Decoder } from "./codec";
 import { Gas } from "./gas";
 import { Interpreter, Status } from "./interpreter";
+import {MemoryBuilder} from "./memory";
 import { Access, PAGE_SIZE } from "./memory-page";
 import { decodeProgram, liftBytes } from "./program";
 import { NO_OF_REGISTERS, REG_SIZE_BYTES, Registers } from "./registers";
 
 let interpreter: Interpreter | null = null;
+let builder = new MemoryBuilder();
 
 export function resetGeneric(program: u8[], flatRegisters: u8[], initialGas: Gas): void {
   const p = decodeProgram(liftBytes(program));
@@ -28,7 +30,7 @@ export function resetGenericWithMemory(
   const registers: Registers = new StaticArray(NO_OF_REGISTERS);
   fillRegisters(registers, flatRegisters);
 
-  const memory = buildMemory(readPages(pageMap), readChunks(chunks));
+  const memory = buildMemory(builder, readPages(pageMap), readChunks(chunks));
 
   const int = new Interpreter(p, registers, memory);
   int.gas.set(initialGas);

--- a/assembly/api.ts
+++ b/assembly/api.ts
@@ -2,13 +2,13 @@ import { InitialChunk, InitialPage, buildMemory } from "./api-generic";
 import { Decoder } from "./codec";
 import { Gas } from "./gas";
 import { Interpreter, Status } from "./interpreter";
-import {MemoryBuilder} from "./memory";
+import { MemoryBuilder } from "./memory";
 import { Access, PAGE_SIZE } from "./memory-page";
 import { decodeProgram, liftBytes } from "./program";
 import { NO_OF_REGISTERS, REG_SIZE_BYTES, Registers } from "./registers";
 
 let interpreter: Interpreter | null = null;
-let builder = new MemoryBuilder();
+const builder = new MemoryBuilder();
 
 export function resetGeneric(program: u8[], flatRegisters: u8[], initialGas: Gas): void {
   const p = decodeProgram(liftBytes(program));

--- a/assembly/memory-page.ts
+++ b/assembly/memory-page.ts
@@ -39,17 +39,17 @@ export class RawPage {
 }
 
 export class Arena {
-  private readonly data: ArrayBuffer;
-  private readonly free: RawPage[];
+  private free: RawPage[];
+  private arenaBytes: number;
   private extraPageIndex: ArenaId;
 
   constructor(pageCount: u32) {
-    const size = PAGE_SIZE * pageCount;
-    this.data = new ArrayBuffer(size);
+    this.arenaBytes = PAGE_SIZE * pageCount;
+    const data = new ArrayBuffer(this.arenaBytes);
     this.free = [];
     this.extraPageIndex = pageCount;
     for (let i = 0; i < <i32>pageCount; i++) {
-      this.free.unshift(new RawPage(i, Uint8Array.wrap(this.data, i * PAGE_SIZE, PAGE_SIZE)));
+      this.free.unshift(new RawPage(i, Uint8Array.wrap(data, i * PAGE_SIZE, PAGE_SIZE)));
     }
   }
 
@@ -60,7 +60,7 @@ export class Arena {
     // no pages!
     const allocatedMemory = this.extraPageIndex * PAGE_SIZE;
     // print warning only once
-    if (allocatedMemory === this.data.byteLength) {
+    if (allocatedMemory === this.arenaBytes) {
       console.log("Warning: Run out of pages! Allocating.");
     }
 
@@ -72,5 +72,14 @@ export class Arena {
 
   release(page: RawPage): void {
     this.free.push(page);
+  }
+
+  /**
+  * Seems like there is an issue with cyclic dependency here that AS GC can't resolve,
+  * so we have to clear the references manually.
+  */
+  destroy(): void {
+    this.free = [];
+    this.extraPageIndex = 0;
   }
 }

--- a/assembly/memory-page.ts
+++ b/assembly/memory-page.ts
@@ -73,13 +73,4 @@ export class Arena {
   release(page: RawPage): void {
     this.free.push(page);
   }
-
-  /**
-  * Seems like there is an issue with cyclic dependency here that AS GC can't resolve,
-  * so we have to clear the references manually.
-  */
-  destroy(): void {
-    this.free = [];
-    this.extraPageIndex = 0;
-  }
 }

--- a/assembly/memory-page.ts
+++ b/assembly/memory-page.ts
@@ -40,14 +40,14 @@ export class RawPage {
 
 export class Arena {
   private free: RawPage[];
-  private arenaBytes: number;
+  private readonly arenaBytes: u32;
   private extraPageIndex: ArenaId;
 
   constructor(pageCount: u32) {
     this.arenaBytes = PAGE_SIZE * pageCount;
-    const data = new ArrayBuffer(this.arenaBytes);
     this.free = [];
     this.extraPageIndex = pageCount;
+    const data = new ArrayBuffer(this.arenaBytes);
     for (let i = 0; i < <i32>pageCount; i++) {
       this.free.unshift(new RawPage(i, Uint8Array.wrap(data, i * PAGE_SIZE, PAGE_SIZE)));
     }

--- a/assembly/memory.ts
+++ b/assembly/memory.ts
@@ -55,6 +55,10 @@ export class MemoryBuilder {
   build(sbrkAddress: u32): Memory {
     return new Memory(this.arena, this.pages, sbrkAddress);
   }
+
+  destroy(): void {
+    this.arena.destroy();
+  }
 }
 
 export class Memory {

--- a/assembly/memory.ts
+++ b/assembly/memory.ts
@@ -98,7 +98,7 @@ export class Memory {
     }
     this.sbrkAddress = u32(newSbrk);
 
-    const pageIdx = i32(newSbrk >> PAGE_SIZE_SHIFT);
+    const pageIdx = i32((newSbrk - 1) >> PAGE_SIZE_SHIFT);
     if (pageIdx === this.lastAllocatedPage) {
       return freeMemoryStart;
     }

--- a/assembly/memory.ts
+++ b/assembly/memory.ts
@@ -55,10 +55,6 @@ export class MemoryBuilder {
   build(sbrkAddress: u32): Memory {
     return new Memory(this.arena, this.pages, sbrkAddress);
   }
-
-  destroy(): void {
-    this.arena.destroy();
-  }
 }
 
 export class Memory {

--- a/bin/fuzz.js
+++ b/bin/fuzz.js
@@ -5,11 +5,16 @@ import fs from 'node:fs';
 import { Pvm } from "@typeberry/pvm-debugger-adapter";
 import { wrapAsProgram, runVm, disassemble, InputKind } from "../build/release.js";
 
+let runNumber = 0;
+
 export function fuzz(data) {
   const gas = 200n;
   const pc = 0;
   const pvm = new Pvm();
   const program = wrapAsProgram(new Uint8Array(data));
+  if (program.length > 100) {
+    return;
+  }
 
   try {
     pvm.reset(
@@ -37,24 +42,26 @@ export function fuzz(data) {
       assert(pvm.getProgramCounter(), output.pc, 'pc');
     });
 
-    // try {
-    //   writeTestCase(
-    //     program,
-    //     {
-    //       pc,
-    //       gas,
-    //       registers,
-    //     },
-    //     {
-    //       status: pvm.getStatus(),
-    //       gasLeft: pvm.getGasLeft(),
-    //       pc: pvm.getProgramCounter(),
-    //       registers: pvm.getRegisters()
-    //     },
-    //   );
-    // } catch (e) {
-    //   console.warn('Unable to write file', e);
-    // }
+    try {
+      if (runNumber % 5000 === 0) {
+        writeTestCase(
+          program,
+          {
+            pc,
+            gas,
+            registers,
+          },
+          {
+            status: pvm.getStatus(),
+            gasLeft: pvm.getGasLeft(),
+            pc: pvm.getProgramCounter(),
+            registers: pvm.getRegisters()
+          },
+        );
+      }
+    } catch (e) {
+      console.warn('Unable to write file', e);
+    }
   } catch (e) {
     const hex = programHex(program);
     console.log(program);

--- a/bin/fuzz.js
+++ b/bin/fuzz.js
@@ -29,7 +29,7 @@ export function fuzz(data) {
       gas,
       program,
     }, printDebugInfo);
-
+    
     collectErrors((assert) => {
       assert(pvm.getStatus(), normalizeStatus(output.status), 'status');
       assert(pvm.getGasLeft(), output.gas, 'gas');
@@ -37,24 +37,24 @@ export function fuzz(data) {
       assert(pvm.getProgramCounter(), output.pc, 'pc');
     });
 
-    try {
-      writeTestCase(
-        program,
-        {
-          pc,
-          gas,
-          registers,
-        },
-        {
-          status: pvm.getStatus(),
-          gasLeft: pvm.getGasLeft(),
-          pc: pvm.getProgramCounter(),
-          registers: pvm.getRegisters()
-        },
-      );
-    } catch (e) {
-      console.warn('Unable to write file', e);
-    }
+    // try {
+    //   writeTestCase(
+    //     program,
+    //     {
+    //       pc,
+    //       gas,
+    //       registers,
+    //     },
+    //     {
+    //       status: pvm.getStatus(),
+    //       gasLeft: pvm.getGasLeft(),
+    //       pc: pvm.getProgramCounter(),
+    //       registers: pvm.getRegisters()
+    //     },
+    //   );
+    // } catch (e) {
+    //   console.warn('Unable to write file', e);
+    // }
   } catch (e) {
     const hex = programHex(program);
     console.log(program);


### PR DESCRIPTION
It seems that AssemblyScript GC had an issue with cyclic dependency within the same class:
```
class Arena {
  buffer: ArrayBuffer,
  pages: Uint8Array[], // These `Uint8Array`s wrap the same `ArrayBuffer` from `this.buffer`
}
```
which was causing memory leaks when running fuzzer.

This PR removes the `buffer` field, which seems to fix the leak. I'll report a minimal reproducible case to assembly script as well.