### PR TITLE
Display PC in disassemble.

### DIFF
--- a/assembly/api-generic.ts
+++ b/assembly/api-generic.ts
@@ -51,7 +51,7 @@ export function getAssembly(p: Program): string {
     const iData = instruction >= <u8>INSTRUCTIONS.length ? MISSING_INSTRUCTION : INSTRUCTIONS[instruction];
 
     v += "\n";
-    v += `${i}: `
+    v += `${i}: `;
     v += changetype<string>(iData.namePtr);
     v += `(${instruction})`;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assembly output now prefixes each instruction line with its numeric index and a colon (e.g., “3: …”), making it easier to reference and discuss specific steps.
  * No other visible changes to formatting or behavior, so existing workflows remain compatible while gaining clearer, indexed instruction lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->