### PR TITLE
Remove whitespace from input.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -53,7 +53,8 @@ function parseRegisters(input) {
   return registers.map(x => BigInt(x));
 }
 
-function parseCode(code) {
+function parseCode(inCode) {
+  const code = inCode.trim();
   if (code.startsWith('0x')) {
     if (code.length % 2 !== 0) {
       throw new Error('uneven number of nibbles');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inputs with leading or trailing spaces are now trimmed automatically before parsing, reducing false errors and improving reliability for both hex and JSON content.
  * Pasted content with extra whitespace is handled more gracefully, without affecting existing parsing behavior.
  * No changes to error messages or other parsing outcomes; overall flow remains consistent while accepting more forgiving input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->