### PR TITLE
Better naming for args-related constants

### DIFF
--- a/assembly/memory-page.ts
+++ b/assembly/memory-page.ts
@@ -1,17 +1,17 @@
 export type PageIndex = u32;
 export type ArenaId = u32;
 
-/** https://graypaper.fluffylabs.dev/#/ab2cdbd/2dad002dad00?v=0.7.2 */
-export const PAGE_SIZE: u32 = 4096;
+/** `Z_P`: https://graypaper.fluffylabs.dev/#/ab2cdbd/44d20044d200?v=0.7.2 */
+export const PAGE_SIZE: u32 = 2 ** 12; // 4_096
 export const PAGE_SIZE_SHIFT: u32 = 12;
 
-/** https://graypaper.fluffylabs.dev/#/ab2cdbd/2daf002daf00?v=0.7.2 */
-export const SEGMENT_SIZE: u32 = 2 ** 16;
+/** `Z_Z`: https://graypaper.fluffylabs.dev/#/ab2cdbd/2daf002daf00?v=0.7.2 */
+export const SEGMENT_SIZE: u32 = 2 ** 16; //65_536
 export const SEGMENT_SIZE_SHIFT: u32 = 16;
 
 /** https://graypaper.fluffylabs.dev/#/ab2cdbd/254401254a01?v=0.7.2 */
-export const RESERVED_MEMORY: u32 = SEGMENT_SIZE;
-export const RESERVED_PAGES: u32 = RESERVED_MEMORY / PAGE_SIZE;
+export const RESERVED_MEMORY: u32 = 2 ** 16;
+export const RESERVED_PAGES: u32 = RESERVED_MEMORY / PAGE_SIZE; // 16
 
 /** Amount of memory to allocate eagerly */
 export const ALLOCATE_EAGERLY: u32 = 2 ** 29; // 512MB

--- a/assembly/spi.ts
+++ b/assembly/spi.ts
@@ -4,18 +4,18 @@ import { Access, PAGE_SIZE, PAGE_SIZE_SHIFT, SEGMENT_SIZE, SEGMENT_SIZE_SHIFT } 
 import { Program, deblob } from "./program";
 import { NO_OF_REGISTERS, Registers } from "./registers";
 
-/** https://graypaper.fluffylabs.dev/#/ab2cdbd/2daf002daf00?v=0.7.2 */
-export const DATA_LENGTH: u32 = 2 ** 24;
+/** `Z_I`: https://graypaper.fluffylabs.dev/#/ab2cdbd/2daf002daf00?v=0.7.2 */
+export const MAX_ARGS_LEN: u32 = 2 ** 24;
 /** https://graypaper.fluffylabs.dev/#/ab2cdbd/2d47022d4702?v=0.7.2 */
-export const ARGS_SEGMENT_START: u32 = 2 ** 32 - SEGMENT_SIZE - DATA_LENGTH;
+export const ARGS_SEGMENT_START: u32 = 2 ** 32 - SEGMENT_SIZE - MAX_ARGS_LEN;
 /** https://graypaper.fluffylabs.dev/#/ab2cdbd/2d33022d3502?v=0.7.2 */
-export const STACK_SEGMENT_END: u32 = 2 ** 32 - 2 * SEGMENT_SIZE - DATA_LENGTH;
+export const STACK_SEGMENT_END: u32 = ARGS_SEGMENT_START - SEGMENT_SIZE;
 
 /** https://graypaper.fluffylabs.dev/#/ab2cdbd/2da3002da300?v=0.7.2 */
 export function decodeSpi(data: Uint8Array, args: Uint8Array): StandardProgram {
   const argsLength = <u32>args.length;
-  if (argsLength > DATA_LENGTH) {
-    throw new Error("Arguments length too big");
+  if (argsLength > MAX_ARGS_LEN) {
+    throw new Error(`Arguments length is too big. Got: ${argsLength}, max: ${MAX_ARGS_LEN}`);
   }
 
   const decoder = new Decoder(data);


### PR DESCRIPTION
Closes #79 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Clearer validation error when SPI argument length exceeds the maximum, including provided and allowed lengths.
- Refactor
  - Standardized memory sizing constants and calculations; renamed argument-length constant for clarity with no functional changes.
- Documentation
  - Updated inline comments to clarify memory segment sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->