### PR TITLE
Inline WASM exports

### DIFF
--- a/bin/build-inline.ts
+++ b/bin/build-inline.ts
@@ -1,0 +1,73 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+
+interface AsconfigTarget {
+	outFile: string;
+	[key: string]: unknown;
+}
+
+interface Asconfig {
+	targets: Record<string, AsconfigTarget>;
+	[key: string]: unknown;
+}
+
+// Load asconfig.json
+const asconfigPath = resolve(projectRoot, "asconfig.json");
+const asconfig: Asconfig = JSON.parse(readFileSync(asconfigPath, "utf-8"));
+
+console.log("Building inline JS files with base64-encoded WASM...\n");
+
+// Process each target
+for (const [targetName, config] of Object.entries(asconfig.targets)) {
+	const wasmPath = resolve(projectRoot, config.outFile);
+
+	try {
+		// Read the WASM file
+		const wasmBuffer = readFileSync(wasmPath);
+
+		// Base64 encode
+		const wasmBase64 = wasmBuffer.toString("base64");
+
+		// Generate the output JS file name
+		// e.g., "build/release.wasm" -> "build/release-inline.js"
+		const wasmFileName = basename(config.outFile, ".wasm");
+		const outputPath = resolve(
+			projectRoot,
+			dirname(config.outFile),
+			`${wasmFileName}-inline.js`
+		);
+
+		// Create the JS content
+		const jsContent = `// Auto-generated inline WASM module
+// Target: ${targetName}
+// Source: ${config.outFile}
+
+export const wasmBase64 = "${wasmBase64}";
+
+// Helper function to decode and instantiate the module
+export async function instantiate(imports) {
+	const wasmBytes = Uint8Array.from(atob(wasmBase64), c => c.charCodeAt(0));
+	return await WebAssembly.instantiate(wasmBytes, imports);
+}
+
+// Helper function to just get the bytes
+export function getWasmBytes() {
+	return Uint8Array.from(atob(wasmBase64), c => c.charCodeAt(0));
+}
+`;
+
+		// Write the JS file
+		writeFileSync(outputPath, jsContent, "utf-8");
+
+		console.log(`✓ ${targetName}: ${outputPath} (${Math.round(wasmBase64.length / 1024)} KB base64)`);
+	} catch (error) {
+		console.error(`✗ ${targetName}: Failed to process ${wasmPath}`);
+		console.error(`  ${error instanceof Error ? error.message : error}`);
+	}
+}
+
+console.log("\nDone!");

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"asbuild:release-stub": "asc assembly/index.ts --uncheckedBehavior=always --target release-stub",
 		"asbuild:raw": "asc assembly/index.ts --target raw",
 		"asbuild:test": "asc assembly/test-run.ts --target test",
-		"build": "npm run asbuild:all && npm run asbuild:test && npm run tsbuild && npm run cp-build",
+		"build": "npm run asbuild:all && npm run asbuild:test && npm run tsbuild && npm run build:inline && npm run cp-build",
+		"build:inline": "tsx ./bin/build-inline.ts",
 		"cp-build": "rm -rf ./web/build; cp -r ./build ./web/",
 		"format": "biome format --write",
 		"fuzz": "tsx ./bin/fuzz.ts",
@@ -78,8 +79,14 @@
 			"types": "./build/debug-raw.d.ts"
 		},
 		"./debug.wasm": "./build/debug.wasm",
+		"./debug-inline.js": "./build/debug-inline.js",
 		"./release.wasm": "./build/release.wasm",
-		"./release-mini.wasm": "./build/release-mini.wasm"
+		"./release-inline.js": "./build/release-inline.js",
+		"./release-mini.wasm": "./build/release-mini.wasm",
+		"./release-mini-inline.js": "./build/release-mini-inline.js",
+		"./release-stub.wasm": "./build/release-stub.wasm",
+		"./release-stub-inline.js": "./build/release-stub-inline.js"
+
 	},
 	"dependencies": {
 		"@typeberry/lib": "^0.2.0",


### PR DESCRIPTION
Resolves #99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced inline WASM variants for all build targets, enabling self-contained module distribution with WebAssembly embedded directly in JavaScript without separate binary files
  * Expanded public module exports to include four new inline build variants (debug-inline, release-inline, release-mini-inline, and release-stub-inline) for enhanced portability and simplified deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->