### PR TITLE
Bump typescript 5.9→6.0 and @biomejs/biome 2.4.6→2.4.10

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -114,7 +114,7 @@ function handleDisassemble(args: string[]) {
     console.error("Supported extensions: .jam, .pvm, .spi, .bin");
     process.exit(1);
   }
-  const ext = file.substring(dotIndex);
+  const ext = file.slice(dotIndex);
   if (!validExtensions.includes(ext)) {
     console.error(`Error: Invalid file extension '${ext}' for disassemble command.`);
     console.error("Supported extensions: .jam, .pvm, .spi, .bin");
@@ -457,8 +457,8 @@ function parseMem(memStr?: string): { address: number; data: number[] }[] {
       throw new Error(`--mem entry ${i} ("${spec}") must be "addr:hexbytes".`);
     }
 
-    const addrStr = spec.substring(0, colonIdx).trim();
-    let hexStr = spec.substring(colonIdx + 1).trim();
+    const addrStr = spec.slice(0, colonIdx).trim();
+    let hexStr = spec.slice(colonIdx + 1).trim();
 
     const address = parseNum(addrStr);
     if (Number.isNaN(address)) {
@@ -467,7 +467,7 @@ function parseMem(memStr?: string): { address: number; data: number[] }[] {
 
     // Strip 0x prefix from hex data
     if (hexStr.startsWith("0x") || hexStr.startsWith("0X")) {
-      hexStr = hexStr.substring(2);
+      hexStr = hexStr.slice(2);
     }
 
     if (hexStr.length % 2 !== 0) {
@@ -476,9 +476,9 @@ function parseMem(memStr?: string): { address: number; data: number[] }[] {
 
     const data: number[] = [];
     for (let j = 0; j < hexStr.length; j += 2) {
-      const byte = parseInt(hexStr.substring(j, j + 2), 16);
+      const byte = parseInt(hexStr.slice(j, j + 2), 16);
       if (Number.isNaN(byte)) {
-        throw new Error(`--mem entry ${i} has invalid hex byte at position ${j}: "${hexStr.substring(j, j + 2)}".`);
+        throw new Error(`--mem entry ${i} has invalid hex byte at position ${j}: "${hexStr.slice(j, j + 2)}".`);
       }
       data.push(byte);
     }

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -476,10 +476,11 @@ function parseMem(memStr?: string): { address: number; data: number[] }[] {
 
     const data: number[] = [];
     for (let j = 0; j < hexStr.length; j += 2) {
-      const byte = parseInt(hexStr.slice(j, j + 2), 16);
-      if (Number.isNaN(byte)) {
-        throw new Error(`--mem entry ${i} has invalid hex byte at position ${j}: "${hexStr.slice(j, j + 2)}".`);
+      const pair = hexStr.slice(j, j + 2);
+      if (!/^[0-9a-fA-F]{2}$/.test(pair)) {
+        throw new Error(`--mem entry ${i} has invalid hex byte at position ${j}: "${pair}".`);
       }
+      const byte = parseInt(pair, 16);
       data.push(byte);
     }
 

--- a/bin/src/utils.ts
+++ b/bin/src/utils.ts
@@ -8,7 +8,7 @@ export function hexDecode(data: string) {
     throw new Error("hex input must start with 0x");
   }
 
-  const hex = data.substring(2);
+  const hex = data.slice(2);
   const len = hex.length;
   if (len % 2 === 1) {
     throw new Error("Odd number of nibbles");
@@ -16,7 +16,7 @@ export function hexDecode(data: string) {
 
   const bytes = new Uint8Array(len / 2);
   for (let i = 0; i < len; i += 2) {
-    const c = hex.substring(i, i + 2);
+    const c = hex.slice(i, i + 2);
     const byteIndex = i / 2;
     if (!/^[0-9a-fA-F]{2}$/.test(c)) {
       throw new Error(`hexDecode: invalid hex pair "${c}" in data "${data}" for bytes[${byteIndex}]`);

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,23 +12,23 @@
 				"anan-as": "dist/bin/index.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "^2.4.5",
+				"@biomejs/biome": "^2.4.10",
 				"@typeberry/lib": "^0.5.8",
 				"@types/node": "^25.3.3",
 				"assemblyscript": "^0.28.9",
 				"esbuild": "^0.28.0",
 				"json-bigint-patch": "^0.0.8",
 				"tsx": "^4.21.0",
-				"typescript": "^5.9.3"
+				"typescript": "^6.0.2"
 			},
 			"engines": {
 				"node": ">=18.3.0"
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
-			"integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.10.tgz",
+			"integrity": "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -42,20 +42,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.6",
-				"@biomejs/cli-darwin-x64": "2.4.6",
-				"@biomejs/cli-linux-arm64": "2.4.6",
-				"@biomejs/cli-linux-arm64-musl": "2.4.6",
-				"@biomejs/cli-linux-x64": "2.4.6",
-				"@biomejs/cli-linux-x64-musl": "2.4.6",
-				"@biomejs/cli-win32-arm64": "2.4.6",
-				"@biomejs/cli-win32-x64": "2.4.6"
+				"@biomejs/cli-darwin-arm64": "2.4.10",
+				"@biomejs/cli-darwin-x64": "2.4.10",
+				"@biomejs/cli-linux-arm64": "2.4.10",
+				"@biomejs/cli-linux-arm64-musl": "2.4.10",
+				"@biomejs/cli-linux-x64": "2.4.10",
+				"@biomejs/cli-linux-x64-musl": "2.4.10",
+				"@biomejs/cli-win32-arm64": "2.4.10",
+				"@biomejs/cli-win32-x64": "2.4.10"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
-			"integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.10.tgz",
+			"integrity": "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==",
 			"cpu": [
 				"arm64"
 			],
@@ -70,9 +70,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
-			"integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.10.tgz",
+			"integrity": "sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==",
 			"cpu": [
 				"x64"
 			],
@@ -87,13 +87,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
-			"integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.10.tgz",
+			"integrity": "sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -104,13 +107,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
-			"integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.10.tgz",
+			"integrity": "sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -121,13 +127,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
-			"integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.10.tgz",
+			"integrity": "sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -138,13 +147,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
-			"integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.10.tgz",
+			"integrity": "sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -155,9 +167,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
-			"integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.10.tgz",
+			"integrity": "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -172,9 +184,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
-			"integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
+			"version": "2.4.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.10.tgz",
+			"integrity": "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==",
 			"cpu": [
 				"x64"
 			],
@@ -1384,9 +1396,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
 		"node": ">=18.3.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.5",
+		"@biomejs/biome": "^2.4.10",
 		"@typeberry/lib": "^0.5.8",
 		"@types/node": "^25.3.3",
 		"assemblyscript": "^0.28.9",
 		"esbuild": "^0.28.0",
 		"json-bigint-patch": "^0.0.8",
 		"tsx": "^4.21.0",
-		"typescript": "^5.9.3"
+		"typescript": "^6.0.2"
 	},
 	"files": [
 		"dist/**/*.wasm",

--- a/portable/tsconfig.json
+++ b/portable/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "target": "ES2020",
     "moduleResolution": "bundler",
+    "rootDir": "..",
     "outDir": "../dist/build/js",
     "declaration": true,
     "lib": ["ES2020", "DOM"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Bump `typescript` from 5.9.3 to 6.0.2 (major)
- Bump `@biomejs/biome` from 2.4.6 to 2.4.10 (patch)
- Fix TS 6 compatibility: add explicit `types: ["node"]` in tsconfig and `rootDir` in portable/tsconfig.json
- Migrate biome schema version and fix `noSubstr` lint violations (`substring` → `slice`)

Supersedes #209 and #212.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)